### PR TITLE
Fixed silent NullReferenceException

### DIFF
--- a/ShutUp/ShutUp.cs
+++ b/ShutUp/ShutUp.cs
@@ -81,8 +81,15 @@ namespace ShutUp
 							level = LogLevel.Info;
 							break;
 					}
-					
-					if (logLevel.TryGetValue(new StackFrame(8).GetMethod().DeclaringType.Assembly, out ConfigEntry<LogLevel> assemblyLogLevel))
+
+					MethodBase methodBase = new StackFrame(8).GetMethod();
+
+					if (methodBase == null || methodBase.DeclaringType == null)
+					{
+						return true;
+					}
+
+					if (logLevel.TryGetValue(methodBase.DeclaringType.Assembly, out ConfigEntry<LogLevel> assemblyLogLevel))
 					{
 						return (assemblyLogLevel.Value & level) != 0;
 					}


### PR DESCRIPTION
Sometimes the MethodBase of `new StackFrame(8).GetMethod()` is null and ShutUp has thrown a NRE. But the error isn't shown inside the BepInEx log, only at the Player.log of Valheim. Because an error was thrown by ShutUp, the original message was not printed and this has resulted in hiding other errors.